### PR TITLE
add ability to retrieve latest stable version

### DIFF
--- a/src/chromedriver.rs
+++ b/src/chromedriver.rs
@@ -4,9 +4,9 @@
 /// See https://chromedriver.chromium.org/downloads/version-selection
 use eyre::{eyre, Result};
 use regex::Regex;
-use tracing::{debug};
-use url::Url;
 use serde_json::Value;
+use tracing::debug;
+use url::Url;
 
 use std::process::{Command, Stdio};
 
@@ -41,9 +41,10 @@ impl DriverFetcher for Chromedriver {
 
     /// Return the latest stable version of the driver
     fn latest_stable_version(&self) -> Result<String> {
-        const VERSION_URL: &'static str = "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE";
+        const VERSION_URL: &'static str =
+            "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE";
         let version_response = reqwest::blocking::get(VERSION_URL)?;
-        
+
         return Ok(version_response.text()?);
     }
 

--- a/src/chromedriver.rs
+++ b/src/chromedriver.rs
@@ -39,6 +39,14 @@ impl DriverFetcher for Chromedriver {
         Err(eyre!("Could not find the latest version"))
     }
 
+    /// Return the latest stable version of the driver
+    fn latest_stable_version(&self) -> Result<String> {
+        const VERSION_URL: &'static str = "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE";
+        let version_response = reqwest::blocking::get(VERSION_URL)?;
+        
+        return Ok(version_response.text()?);
+    }
+
     /// Returns the download url for the driver executable
     fn direct_download_url(&self, version: &str) -> Result<Url> {
         Ok(Url::parse(&format!(

--- a/src/geckodriver.rs
+++ b/src/geckodriver.rs
@@ -15,6 +15,11 @@ impl DriverFetcher for Geckodriver {
         Ok(url.path_segments().unwrap().last().unwrap().to_string())
     }
 
+    /// Returns the latest stable version of the driver
+    fn latest_stable_version(&self) -> Result<String> {
+        self.latest_version()
+    }
+
     /// Returns the download url for the driver executable
     fn direct_download_url(&self, version: &str) -> Result<Url> {
         Ok(Url::parse(&format!(
@@ -24,6 +29,7 @@ impl DriverFetcher for Geckodriver {
             platform = Self::platform()?
         ))?)
     }
+    
 }
 
 impl Geckodriver {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub trait DriverFetcher {
     const BASE_URL: &'static str;
 
     fn latest_version(&self) -> Result<String>;
+    
+    fn latest_stable_version(&self) -> Result<String>;
 
     fn direct_download_url(&self, version: &str) -> Result<Url>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub trait DriverFetcher {
     const BASE_URL: &'static str;
 
     fn latest_version(&self) -> Result<String>;
-    
+
     fn latest_stable_version(&self) -> Result<String>;
 
     fn direct_download_url(&self, version: &str) -> Result<Url>;


### PR DESCRIPTION
Been using this crate recently so I'm going to drop this in here in case anyone wants to take a look.

For chromedriver, the latest versions require developer versions of chrome to be installed. The stable versions do not have this requirement and work with the normal chrome installation versions that would be more common on users' machines.

I didn't mess with the existing public API in this PR but just created a minimum viable working version. It would be nice to have an API like this though:

```rust
let version = Version::Latest; // Version::Latest, Version::Stable, Version::Dev, etc.
Driver::Chrome.install_version(version);
```

I might get around to creating that if I can find some time.